### PR TITLE
Define "entity", be more deliberate in using entity VS node VS host, and traffic VS flows

### DIFF
--- a/draft-irtf-panrg-path-properties.md
+++ b/draft-irtf-panrg-path-properties.md
@@ -84,6 +84,9 @@ Note that this document does not assume that any of the listed path properties a
 
 # Terminology
 
+Entity:
+: A physical or virtual device or function which can process packets (i.e., a node or host), measure path properties, or access information about paths. With respect to a given communication (i.e., a flow), an entity may be on the data plane or control plane, and it may be on-path or off-path.
+
 Node:
 : An entity which processes packets, e.g., sends, receives, forwards, or modifies them. A node may be physical or virtual, e.g., a physical device or a service function provided as a virtual element. A node may also be the collection of multiple entities which, as a collection, processes packets, e.g., an entire Autonomous System (AS).
 
@@ -108,7 +111,7 @@ Subpath:
 : Given a path, a subpath is a sequence of adjacent path elements of this path.
 
 Flow:
-: An entity made of packets to which the traits of a path or set of subpaths may be applied in a functional sense. For example, a flow can consist of all packets sent within a TCP session with the same five-tuple between two hosts, or it can consist of all packets sent on the same physical link.
+: One or multiple packets to which the traits of a path or set of subpaths may be applied in a functional sense. For example, a flow can consist of all packets sent within a TCP session with the same five-tuple between two hosts, or it can consist of all packets sent on the same physical link.
 
 Property:
 : A trait of one or a sequence of path elements, or a trait of a flow with respect to one or a sequence of path elements. An example of a link property is the maximum data rate that can be sent over the link. An example of a node property is the administrative domain that the node belongs to. An example of a property of a flow with respect to a subpath is the aggregated one-way delay of the flow being sent from one node to another node over this subpath.
@@ -143,26 +146,26 @@ Therefore, a new technology may implement an existing use case related to differ
 
 ## Path Selection
 
-Entities can choose what traffic to send over which path or subset of paths.
-A node might be able to select between a set of paths, either if there are several paths to the same destination (e.g., in case of a mobile device with two wireless interfaces, both providing a path), or if there are several destinations, and thus several paths, providing the same service (e.g., Application-Layer Traffic Optimization (ALTO) {{RFC5693}}, an application layer peer-to-peer protocol allowing hosts a better-than-random peer selection).
+Nodes may be able to send flows via one out of multiple possible paths, or via a subsets of paths, and an entity may be able to select which path(s) to use.
+Path Selection may be feasible if there are several paths to the same destination (e.g., in case of a mobile device with two wireless interfaces, both providing a path), or if there are several destinations, and thus several paths, providing the same service (e.g., Application-Layer Traffic Optimization (ALTO) {{RFC5693}}, an application layer peer-to-peer protocol allowing hosts a better-than-random peer selection).
 Care needs to be taken when selecting paths based on path properties, as path properties that were previously measured may not be helpful in predicting current or future path properties and such path selection may lead to unintended feedback loops.
 
 Entities may select their paths to fulfill a specific goal, e.g., related to security or performance.
-As an example of security-related path selection, an entity may allow or disallow sending traffic over paths involving specific networks or nodes to enforce traffic policies. In an enterprise network where all traffic has to go through a specific firewall, a path-aware host can implement this policy using path selection, in which case the host needs to be aware of paths involving that firewall.
+As an example of security-related path selection, an entity may allow or disallow sending flows over paths involving specific networks or nodes to enforce traffic policies. In an enterprise network where all traffic has to go through a specific firewall, a path-aware entity can implement this policy using path selection.
 As an example of performance-related path selection,
-an entity may prefer paths with performance properties that best match its traffic requirements.
-For example, for sending a small delay sensitive query, a host may select a path with a short One-Way Delay,
+an entity may prefer paths with performance properties that best match application requirements.
+For example, for sending a small delay sensitive query, the entity may select a path with a short One-Way Delay,
 while for retrieving a large file, it may select a path with high Link Capacities on all links.
 Note, there may be trade-offs between path properties (e.g., One-Way Delay and Link Capacity), and entities may influence these trade-offs with their choices.
 As a baseline, a path selection algorithm should aim to not perform worse than the default case most of the time.
 
-Path selection can be done both by hosts and by entities within the network:
+Path selection can be done either by the communicating node(s) or by other entities within the network:
 A network (e.g., an AS) can adjust its path selection for internal or external routing based on path properties.
 In BGP, the Multi Exit Discriminator (MED) attribute is used in the decision-making process to select which path to choose among those having the same AS PATH length and origin {{RFC4271}}; in a path-aware network, instead of using this single MED value, other properties such as Link Capacity or Link Usage could additionally be used to improve load balancing or performance {{I-D.ietf-idr-performance-routing}}.
 
 ## Protocol Selection
 
-When sending traffic over a specific path, an entity may select an appropriate protocol or configure protocol parameters depending on path properties.
+Before sending data over a specific path, an entity may select an appropriate protocol or configure protocol parameters depending on path properties.
 A host may cache state on whether a path allows the use of QUIC {{I-D.ietf-quic-transport}} and if so, first attempt to connect using QUIC before falling back to another protocol when connecting over this path again.
 A video streaming application may choose an (initial) video quality based on the achievable data rate or the monetary cost of sending data (e.g., volume-base or flat-rate cost model).
 
@@ -256,7 +259,7 @@ In order to be able to trust such path properties, nodes may need to establish a
 Security related properties such as confidentiality and integrity protection of payloads are difficult to characterize since they are only meaningful with respect to a threat model which depends on the use case, application, environment, and other factors.
 Likewise, properties for trust relations between nodes cannot be meaningfully defined without a concrete threat model, and defining a threat model is out of scope for this draft.
 Properties related to confidentiality, integrity, and trust are orthogonal to the path terminology and path properties defined in this document.
-Such properties are tied to the communicating entities and protocols used (e.g., client and server using HTTPS, or client and remote network node using VPN) while the path is typically oblivious to them.
+Such properties are tied to the communicating nodes and the protocols they use (e.g., client and server using HTTPS, or client and remote network node using VPN) while the path is typically oblivious to them.
 Intuitively, the path describes what function the network applies to packets, while confidentiality, integrity, and trust describe what function the communicating parties apply to packets.
 
 

--- a/draft-irtf-panrg-path-properties.md
+++ b/draft-irtf-panrg-path-properties.md
@@ -85,10 +85,10 @@ Note that this document does not assume that any of the listed path properties a
 # Terminology
 
 Entity:
-: A physical or virtual device or function which can process packets (i.e., a node or host), measure path properties, or access information about paths. With respect to a given communication (i.e., a flow), an entity may be on the data plane or control plane, and it may be on-path or off-path.
+: A physical or virtual device or function, or a collection of devices or functions, which can, for example, process packets, measure path properties, or access information about paths. With respect to a given communication, an entity may be on the data plane or control plane, and it may be on-path or off-path.
 
 Node:
-: An entity which processes packets, e.g., sends, receives, forwards, or modifies them. A node may be physical or virtual, e.g., a physical device or a service function provided as a virtual element. A node may also be the collection of multiple entities which, as a collection, processes packets, e.g., an entire Autonomous System (AS).
+: An entity which processes packets, e.g., sends, receives, forwards, or modifies them. A node may be physical or virtual, e.g., a physical device or a service function provided as a virtual element. A node may also be an entity which, as a collection, processes packets, e.g., an entire Autonomous System (AS).
 
 Host:
 : A node that generally executes application programs on behalf of user(s), employing network and/or Internet communication services in support of this function, as defined in {{?RFC1122}}.
@@ -146,7 +146,7 @@ Therefore, a new technology may implement an existing use case related to differ
 
 ## Path Selection
 
-Nodes may be able to send flows via one out of multiple possible paths, or via a subsets of paths, and an entity may be able to select which path(s) to use.
+Nodes may be able to send flows via one (or a subset) out of multiple possible paths, and an entity may be able to influence the decision which path(s) to use.
 Path Selection may be feasible if there are several paths to the same destination (e.g., in case of a mobile device with two wireless interfaces, both providing a path), or if there are several destinations, and thus several paths, providing the same service (e.g., Application-Layer Traffic Optimization (ALTO) {{RFC5693}}, an application layer peer-to-peer protocol allowing hosts a better-than-random peer selection).
 Care needs to be taken when selecting paths based on path properties, as path properties that were previously measured may not be helpful in predicting current or future path properties and such path selection may lead to unintended feedback loops.
 

--- a/draft-irtf-panrg-path-properties.md
+++ b/draft-irtf-panrg-path-properties.md
@@ -88,7 +88,7 @@ Entity:
 : A physical or virtual device or function, or a collection of devices or functions, which can, for example, process packets, measure path properties, or access information about paths. With respect to a given communication, an entity may be on the data plane or control plane, and it may be on-path or off-path.
 
 Node:
-: An entity which processes packets, e.g., sends, receives, forwards, or modifies them. A node may be physical or virtual, e.g., a physical device or a service function provided as a virtual element. A node may also be an entity which, as a collection, processes packets, e.g., an entire Autonomous System (AS).
+: An entity which processes packets, e.g., sends, receives, forwards, or modifies them. A node may be physical or virtual, e.g., a physical device or a service function provided as a virtual element. A node may also be an entity which consists of a collection of devices or functions, e.g., an entire Autonomous System (AS).
 
 Host:
 : A node that generally executes application programs on behalf of user(s), employing network and/or Internet communication services in support of this function, as defined in {{?RFC1122}}.


### PR DESCRIPTION
When examining our use of "entity", I found that often we really mean anything that is either a node or measures path properties or processes them and potentially makes decisions based on them, e.g., path selection.
Therefore, I kept "entity" in most places, but added a definition as suggested by Med.

Also chose terms more deliberately in the "Path Selection" section - paths can be selected by any entity, not just the communicating node. And "traffic" is undefined so I substituted it by "flows" when we really just mean flows... or "data" when the packet has not actually been created yet (i.e., before a protocol has been selected).