### PR TITLE
Rephrase time-dependent part of path definition

### DIFF
--- a/draft-irtf-panrg-path-properties.md
+++ b/draft-irtf-panrg-path-properties.md
@@ -135,7 +135,7 @@ Path:
   A multicast or broadcast setting, where a packet is sent by one node and received by multiple nodes, is described by multiple paths over which the packet is sent, one path for each combination of sending and receiving node; these paths do not have to be disjoint.
 
 Endpoint:
-: The endpoints of a path are the first and the last node on the path. For example, an endpoint can be a host as defined in {{?RFC1122}}, which can be a client (e.g., a node running a web browser) or a server (e.g., a node running a web server).
+: The endpoints of a path are the start and end node of the path. For example, an endpoint can be a host as defined in {{?RFC1122}}, which can be a client (e.g., a node running a web browser) or a server (e.g., a node running a web server).
 
 Reverse Path:
 : The path that is used by a remote node in the context of bidirectional communication.

--- a/draft-irtf-panrg-path-properties.md
+++ b/draft-irtf-panrg-path-properties.md
@@ -125,7 +125,7 @@ Path:
 : A sequence of adjacent path elements over which a packet can be transmitted, starting and ending with a node.
 
   Paths are unidirectional and time-dependent, i.e., there can be a variety of paths from one node to another, and the path over which packets are transmitted may change.
-  A path definition can be strict, i.e., the sequence of path elements remains the same, or loose, i.e., the sequence of path elements may vary over time.
+  A path definition can be strict (i.e., the exact sequence of path elements remains the same) or loose (i.e., a subset of path elements may vary over time).
 
   The representation of a path and its properties may depend on the entity considering the path.
   On the one hand, the representation may differ due to entities having partial visibility of path elements comprising a path or their visibility changing over time.

--- a/draft-irtf-panrg-path-properties.md
+++ b/draft-irtf-panrg-path-properties.md
@@ -125,6 +125,7 @@ Path:
 : A sequence of adjacent path elements over which a packet can be transmitted, starting and ending with a node.
 
   Paths are unidirectional and time-dependent, i.e., there can be a variety of paths from one node to another, and the path over which packets are transmitted may change.
+  A path definition can be strict, i.e., the sequence of path elements remains the same, or loose, i.e., the sequence of path elements may vary over time.
 
   The representation of a path and its properties may depend on the entity considering the path.
   On the one hand, the representation may differ due to entities having partial visibility of path elements comprising a path or their visibility changing over time.

--- a/draft-irtf-panrg-path-properties.md
+++ b/draft-irtf-panrg-path-properties.md
@@ -125,7 +125,7 @@ Path:
 : A sequence of adjacent path elements over which a packet can be transmitted, starting and ending with a node.
 
   Paths are unidirectional and time-dependent, i.e., there can be a variety of paths from one node to another, and the path over which packets are transmitted may change.
-  A path definition can be strict (i.e., the exact sequence of path elements remains the same) or loose (i.e., a subset of path elements may vary over time).
+  A path definition can be strict (i.e., the exact sequence of path elements remains the same) or loose (i.e., the start and end node remain the same, but the path elements between them may vary over time).
 
   The representation of a path and its properties may depend on the entity considering the path.
   On the one hand, the representation may differ due to entities having partial visibility of path elements comprising a path or their visibility changing over time.

--- a/draft-irtf-panrg-path-properties.md
+++ b/draft-irtf-panrg-path-properties.md
@@ -124,7 +124,7 @@ Path element:
 Path:
 : A sequence of adjacent path elements over which a packet can be transmitted, starting and ending with a node.
 
-  Paths are unidirectional and time-dependent, i.e., there can be a variety of paths from one node to another, and the path over which packets are transmitted may change during the lifetime of a flow.
+  Paths are unidirectional and time-dependent, i.e., there can be a variety of paths from one node to another, and the path over which packets are transmitted may change.
 
   The representation of a path and its properties may depend on the entity considering the path.
   On the one hand, the representation may differ due to entities having partial visibility of path elements comprising a path or their visibility changing over time.

--- a/draft-irtf-panrg-path-properties.md
+++ b/draft-irtf-panrg-path-properties.md
@@ -124,7 +124,7 @@ Path element:
 Path:
 : A sequence of adjacent path elements over which a packet can be transmitted, starting and ending with a node.
 
-  Paths are unidirectional and time-dependent, i.e., the sequence of path elements over which packets are sent from one node to another may change.
+  Paths are unidirectional and time-dependent, i.e., there can be a variety of paths from one node to another, and the path over which packets are transmitted may change during the lifetime of a flow.
 
   The representation of a path and its properties may depend on the entity considering the path.
   On the one hand, the representation may differ due to entities having partial visibility of path elements comprising a path or their visibility changing over time.


### PR DESCRIPTION
Clarify the point raised by Dave Oran in #86 - Packets may traverse a different path, but any particular path itself does not change its composition.
This is a strict path definition, and my changes are intended to clarify it, rather than change/add anything to the definition.

In the issue, Med brought up a loose path definition, as related to the [Time-Variant Routing (TVR) proposed WG](https://datatracker.ietf.org/wg/tvr/about/).

Upon further reflection, I wonder if this use case could be accomodated using our current path definition, e.g., if a path gets disrupted, it no longer exists as such (as no packets can be transmitted over it anymore), but a different path may have started to exist.

If this works, I would prefer to keep our path definition as-is, rather than adding a loose definition to it, as it is already long and complicated. 
If we have to add the loose definition, I wonder if we should confirm this with the Research Group.