### PR TITLE
Clarify that the path selection should be better than not selecting a path

### DIFF
--- a/draft-irtf-panrg-path-properties.md
+++ b/draft-irtf-panrg-path-properties.md
@@ -201,7 +201,7 @@ Care needs to be taken when selecting paths based on observed path properties, a
 Finally, path selection may impact fairness.
 For example, if multiple entities concurrently attempt to meet their target properties using the same network resources, one entity's choices may influence the conditions on the path as experienced by flows of another entity.
 
-As a baseline, a path selection algorithm should aim to not perform worse than the default case of not selecting a path most of the time.
+As a baseline, a path selection algorithm should aim to do a better job at meeting the target properties or accomodating the user's requirements than the default case of not selecting a path most of the time.
 
 Path selection can be done either by the communicating node(s) or by other entities within the network:
 A network (e.g., an AS) can adjust its path selection for internal or external routing based on path properties.

--- a/draft-irtf-panrg-path-properties.md
+++ b/draft-irtf-panrg-path-properties.md
@@ -201,7 +201,7 @@ Care needs to be taken when selecting paths based on observed path properties, a
 Finally, path selection may impact fairness.
 For example, if multiple entities concurrently attempt to meet their target properties using the same network resources, one entity's choices may influence the conditions on the path as experienced by flows of another entity.
 
-As a baseline, a path selection algorithm should aim to do a better job at meeting the target properties or accomodating the user's requirements than the default case of not selecting a path most of the time.
+As a baseline, a path selection algorithm should aim to do a better job at meeting the target properties, and consequently accommodating the user's requirements, than the default case of not selecting a path most of the time.
 
 Path selection can be done either by the communicating node(s) or by other entities within the network:
 A network (e.g., an AS) can adjust its path selection for internal or external routing based on path properties.

--- a/draft-irtf-panrg-path-properties.md
+++ b/draft-irtf-panrg-path-properties.md
@@ -201,7 +201,7 @@ Care needs to be taken when selecting paths based on observed path properties, a
 Finally, path selection may impact fairness.
 For example, if multiple entities concurrently attempt to meet their target properties using the same network resources, one entity's choices may influence the conditions on the path as experienced by flows of another entity.
 
-As a baseline, a path selection algorithm should aim to not perform worse than the default case most of the time.
+As a baseline, a path selection algorithm should aim to not perform worse than the default case of not selecting a path most of the time.
 
 Path selection can be done either by the communicating node(s) or by other entities within the network:
 A network (e.g., an AS) can adjust its path selection for internal or external routing based on path properties.


### PR DESCRIPTION
Fix #87 - The default case is that we don't do path selection at all. 
What exactly happens then will depend on the context, but I'd say this usually means that a single "default" path is used, which may be statically configured. But I don't think it's necessary to spell this out here.
I am pretty sure that we don't want to compare it to a random selection, because I've often seen cases where the default path is "good" and the alternative path is just unsuitable. In such a case, if you select the path randomly, you'll perform much worse than the default of not doing path selection at all.